### PR TITLE
Pass HTTP status code with "Unacceptable HTTP code" exception

### DIFF
--- a/src/fetch-please.js
+++ b/src/fetch-please.js
@@ -354,7 +354,9 @@ class FetchPlease {
 
         // If status < 200 or status >= 200 then return error
         if (status < MIN_SUCCESSFUL_HTTP_CODE || status > MAX_SUCCESSFUL_HTTP_CODE) {
-            throw new Error(ERROR_UNACCEPTABLE_HTTP_CODE);
+            let error = new Error(ERROR_UNACCEPTABLE_HTTP_CODE);
+            error.statusCode = status;
+            throw error;
         }
 
         // Just return given xhr
@@ -368,7 +370,7 @@ class FetchPlease {
      */
     handleError(error) {
         // Really do nothing
-        throw new Error(error.message);
+        throw error;
     }
 }
 

--- a/test/request.spec.js
+++ b/test/request.spec.js
@@ -135,6 +135,7 @@ describe('Method request()', () => {
             expect(this.api.opened.length).to.equal(0);
             expect(error).to.be.an.instanceOf(Error);
             expect(error.message).to.equal(ERROR_UNACCEPTABLE_HTTP_CODE);
+            expect(error.statusCode).to.equal(404);
         });
     });
 


### PR DESCRIPTION
This make it easy to handle status codes the application is interested in.
